### PR TITLE
Adding a switch to support newer o3d versions 

### DIFF
--- a/src/open3d_conversions/open3d_conversions.py
+++ b/src/open3d_conversions/open3d_conversions.py
@@ -57,13 +57,23 @@ def from_msg(ros_cloud):
     mask = np.isfinite(xyzrgb_array['x']) & np.isfinite(xyzrgb_array['y']) & np.isfinite(xyzrgb_array['z'])
     cloud_array = xyzrgb_array[mask]
 
-    open3d_cloud = open3d.PointCloud()
+    # Handle legacy API
+    if hasattr(open3d, "PointCloud"):
+        open3d_cloud = open3d.PointCloud()
+    else:
+        open3d_cloud = open3d.geometry.PointCloud()
+
+    if hasattr(open3d, "Vector3dVector"):
+        vector_type = open3d.Vector3dVector
+    else:
+        vector_type = open3d.utility.Vector3dVector
+
 
     points = np.zeros(cloud_array.shape + (3,), dtype=np.float)
     points[..., 0] = cloud_array['x']
     points[..., 1] = cloud_array['y']
     points[..., 2] = cloud_array['z']
-    open3d_cloud.points = open3d.Vector3dVector(points)
+    open3d_cloud.points = vector_type(points)
 
     if 'rgb' in xyzrgb_array.dtype.names:
         rgb_array = ros_numpy.point_cloud2.split_rgb_field(xyzrgb_array)
@@ -74,6 +84,6 @@ def from_msg(ros_cloud):
         colors[..., 1] = cloud_array['g']
         colors[..., 2] = cloud_array['b']
 
-        open3d_cloud.colors = open3d.Vector3dVector(colors / 255.0)
+        open3d_cloud.colors = vector_type(colors / 255.0)
 
     return open3d_cloud


### PR DESCRIPTION
Hi!

In newer open3d versions, some of the used types in your repository have been moved into submodules.
See for example this PR: https://github.com/isl-org/Open3D/issues/2630#issuecomment-729131328

This PR adds support for newer o3d versions by checking if the required types are existing in the open3d root namespace or if their most recent module path has to be used.